### PR TITLE
update javametrics to latest level

### DIFF
--- a/generator-liberty/generators/app/templates/liberty/config.js
+++ b/generator-liberty/generators/app/templates/liberty/config.js
@@ -14,8 +14,8 @@
     {"groupId" : "org.apache.cxf", "artifactId" : "cxf-rt-rs-client", "version" : "3.1.11", "scope" : "test"},
     {"groupId" : "org.glassfish", "artifactId" : "javax.json", "version" : "1.0.4", "scope" : "test"},
     {{#javametrics}}
-    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-agent", "version" : "1.0.1", "scope" : "provided"},
-    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-dash", "version" : "1.0.1", "scope" : "provided", "type" : "war"}
+    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-agent", "version" : "1.1.0", "scope" : "provided"},
+    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-dash", "version" : "1.1.0", "scope" : "provided", "type" : "war"}
     {{/javametrics}}
   ],
   "frameworkDependencies" : [

--- a/generator-liberty/lib/assert.liberty.js
+++ b/generator-liberty/lib/assert.liberty.js
@@ -71,8 +71,8 @@ function AssertLiberty() {
       self.assertFeature(exists, "websocket-1.1");
 
       const depcheck = exists ? tests.test(buildType).assertDependency : tests.test(buildType).assertNoDependency;
-      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-agent', '1.0.1');
-      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-dash', '1.0.1');
+      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-agent', '1.1.0');
+      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-dash', '1.1.0');
 
     });
   }


### PR DESCRIPTION
javametrics is now released at level 1.1.0 to maven.  This pull request is to update the level the generators to use to be that new level