### PR TITLE
feat(templates): Update Liberty runtime to version 17.0.0.4

### DIFF
--- a/generator-liberty/generators/app/templates/build/build.gradle
+++ b/generator-liberty/generators/app/templates/build/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.0.1'
+        classpath 'net.wasdev.wlp.gradle.plugins:liberty-gradle-plugin:2.1'
         classpath files('gradle/wlp-anttasks.jar')
         {{#has platforms 'bluemix'}}
         classpath 'org.cloudfoundry:cf-gradle-plugin:1.1.2'
@@ -59,7 +59,7 @@ dependencies {
     } {{/if}}
     {{/each}}
     {{#unless libertybeta}}
-    libertyRuntime ('com.ibm.websphere.appserver.runtime:wlp-webProfile7:17.0.0.3')
+    libertyRuntime ('com.ibm.websphere.appserver.runtime:wlp-webProfile7:17.0.0.4')
     {{/unless}}
 }
 
@@ -109,6 +109,27 @@ liberty {
             include = packagingType
         }
      }
+}
+
+libertyPackage {
+    def originalOutputDir
+    doFirst {
+        originalOutputDir = server.outputDir
+        server.outputDir = "$buildDir/liberty-alt-output-dir"
+    }
+    doLast {
+        server.outputDir = originalOutputDir
+    }
+}
+installFeature {
+    def originalOutputDir
+    doFirst {
+        originalOutputDir = server.outputDir
+        server.outputDir = "$buildDir/liberty-alt-output-dir"
+    }
+    doLast {
+        server.outputDir = originalOutputDir
+    }
 }
 
 task libertyStartTestServer(type: net.wasdev.wlp.gradle.plugins.tasks.StartTask){

--- a/generator-liberty/generators/app/templates/build/pom.xml
+++ b/generator-liberty/generators/app/templates/build/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>net.wasdev.wlp.maven.parent</groupId>
         <artifactId>liberty-maven-app-parent</artifactId>
-        <version>2.1.1</version>
+        <version>2.1.2</version>
     </parent>
 
     <properties>
@@ -145,7 +145,6 @@
             <plugin>
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>2.1.1</version>
                 <configuration>
                     {{#libertybeta}}
                     <install>
@@ -156,7 +155,7 @@
                     <assemblyArtifact>
                         <groupId>com.ibm.websphere.appserver.runtime</groupId>
                         <artifactId>wlp-webProfile7</artifactId>
-                        <version>17.0.0.3</version>
+                        <version>17.0.0.4</version>
                         <type>zip</type>
                     </assemblyArtifact>
                     {{/libertybeta}}
@@ -170,23 +169,11 @@
                         <default.http.port>${testServerHttpPort}</default.http.port>
                         <default.https.port>${testServerHttpsPort}</default.https.port>
                     </bootstrapProperties>
+                    <features>
+                        <acceptLicense>true</acceptLicense>
+                    </features>
                     <looseApplication>false</looseApplication>
                 </configuration>
-                <executions>
-                    <execution>
-                        <id>install-feature</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                          <goal>install-feature</goal>
-                        </goals>
-                        <configuration>
-                            <features>
-                                <acceptLicense>true</acceptLicense>
-                            </features>
-                            <outputDirectory>target/liberty-alt-output-dir</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>

--- a/generator-liberty/lib/assert.liberty.js
+++ b/generator-liberty/lib/assert.liberty.js
@@ -26,7 +26,7 @@ const README_MD = 'README.md';
 const JVM_OPTIONS = 'src/main/liberty/config/jvm.options';
 const IBM_WEB_EXT = 'src/main/webapp/WEB-INF/ibm-web-ext.xml';
 const JVM_OPTIONS_JAVAAGENT = '-javaagent:resources/javametrics-agent.jar';
-const LIBERTY_VERSION = '17.0.0.3';   //current Liberty version to check for
+const LIBERTY_VERSION = '17.0.0.4';   //current Liberty version to check for
 const LIBERTY_BETA_VERSION = '2017.+';   //current Liberty beta version to check for
 const tests = require('ibm-java-codegen-common');
 


### PR DESCRIPTION
* update Liberty runtime to version 17.0.0.4
* update Liberty Maven plugin to version 2.1.2
* update Liberty Gradle plugin to version 2.1 and configure installFeature and libertyPackage task to use alternate output directory to support running gradle assemble command with running Liberty server.

Signed-off-by: Patrick Tiu <tiu@ca.ibm.com>