### PR TITLE
fix(lib): move dev dependencies to dependencies in package.json

### DIFF
--- a/generator-liberty/package.json
+++ b/generator-liberty/package.json
@@ -16,11 +16,11 @@
     "ibm-java-codegen-common": "3.0.0",
     "unzip2": "^0.2.5",
     "bluebird": "^3.5.0",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "yeoman-assert": "^2.2.2"
   },
   "devDependencies": {
     "mocha": "^3.2.0",
-    "yeoman-assert": "^2.2.2",
     "yeoman-test": "^1.6.0",
     "standard-version": "^4.2.0",
     "coveralls": "^2.13.3",


### PR DESCRIPTION
Now tests are exported the corresponding dependencies need to be installed by default

Signed off by : Adam Pilkington apilkington@uk.ibm.com