### PR TITLE
Use version range instead of fixed version for javametrics and add REST API

### DIFF
--- a/generator-liberty/generators/app/templates/build/pom.xml
+++ b/generator-liberty/generators/app/templates/build/pom.xml
@@ -115,6 +115,17 @@
                       </configuration>
                     </execution>
                     <execution>
+                        <id>copy-javametrics-rest</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                          <stripVersion>true</stripVersion>
+                          <outputDirectory>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/dropins</outputDirectory>
+                          <includeArtifactIds>javametrics-rest</includeArtifactIds>
+                      </configuration>
+                    </execution>                    <execution>
                         <id>copy-javametrics-agent</id>
                         <phase>package</phase>
                         <goals>

--- a/generator-liberty/generators/app/templates/build/pom.xml
+++ b/generator-liberty/generators/app/templates/build/pom.xml
@@ -121,11 +121,12 @@
                             <goal>copy-dependencies</goal>
                         </goals>
                         <configuration>
-                          <stripVersion>true</stripVersion>
-                          <outputDirectory>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/dropins</outputDirectory>
-                          <includeArtifactIds>javametrics-rest</includeArtifactIds>
+                            <stripVersion>true</stripVersion>
+                            <outputDirectory>${project.build.directory}/liberty/wlp/usr/servers/defaultServer/dropins</outputDirectory>
+                            <includeArtifactIds>javametrics-rest</includeArtifactIds>
                       </configuration>
-                    </execution>                    <execution>
+                    </execution>
+                    <execution>
                         <id>copy-javametrics-agent</id>
                         <phase>package</phase>
                         <goals>

--- a/generator-liberty/generators/app/templates/liberty/config.js
+++ b/generator-liberty/generators/app/templates/liberty/config.js
@@ -14,8 +14,9 @@
     {"groupId" : "org.apache.cxf", "artifactId" : "cxf-rt-rs-client", "version" : "3.1.11", "scope" : "test"},
     {"groupId" : "org.glassfish", "artifactId" : "javax.json", "version" : "1.0.4", "scope" : "test"},
     {{#javametrics}}
-    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-agent", "version" : "[1.1,2.0)", "scope" : "provided"},
-    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-dash", "version" : "[1.1,2.0)", "scope" : "provided", "type" : "war"}
+    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-agent", "version" : "[1.2,2.0)", "scope" : "provided"},
+    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-dash", "version" : "[1.2,2.0)", "scope" : "provided", "type" : "war"},
+    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-rest", "version" : "[1.2,2.0)", "scope" : "provided", "type" : "war"}
     {{/javametrics}}
   ],
   "frameworkDependencies" : [

--- a/generator-liberty/generators/app/templates/liberty/config.js
+++ b/generator-liberty/generators/app/templates/liberty/config.js
@@ -14,8 +14,8 @@
     {"groupId" : "org.apache.cxf", "artifactId" : "cxf-rt-rs-client", "version" : "3.1.11", "scope" : "test"},
     {"groupId" : "org.glassfish", "artifactId" : "javax.json", "version" : "1.0.4", "scope" : "test"},
     {{#javametrics}}
-    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-agent", "version" : "1.1.0", "scope" : "provided"},
-    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-dash", "version" : "1.1.0", "scope" : "provided", "type" : "war"}
+    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-agent", "version" : "[1.1,2.0)", "scope" : "provided"},
+    {"groupId" : "com.ibm.runtimetools", "artifactId" : "javametrics-dash", "version" : "[1.1,2.0)", "scope" : "provided", "type" : "war"}
     {{/javametrics}}
   ],
   "frameworkDependencies" : [

--- a/generator-liberty/lib/assert.liberty.js
+++ b/generator-liberty/lib/assert.liberty.js
@@ -71,8 +71,9 @@ function AssertLiberty() {
       self.assertFeature(exists, "websocket-1.1");
 
       const depcheck = exists ? tests.test(buildType).assertDependency : tests.test(buildType).assertNoDependency;
-      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-agent', '\\[1.1,2.0\\)');
-      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-dash', '\\[1.1,2.0\\)');
+      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-agent', '\\[1.2,2.0\\)');
+      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-rest', '\\[1.2,2.0\\)');
+      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-dash', '\\[1.2,2.0\\)');
 
     });
   }

--- a/generator-liberty/lib/assert.liberty.js
+++ b/generator-liberty/lib/assert.liberty.js
@@ -71,8 +71,8 @@ function AssertLiberty() {
       self.assertFeature(exists, "websocket-1.1");
 
       const depcheck = exists ? tests.test(buildType).assertDependency : tests.test(buildType).assertNoDependency;
-      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-agent', '1.1.0');
-      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-dash', '1.1.0');
+      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-agent', '\\[1.1,2.0\\)');
+      depcheck('provided', 'com.ibm.runtimetools', 'javametrics-dash', '\\[1.1,2.0\\)');
 
     });
   }


### PR DESCRIPTION
See https://github.com/ibm-developer/generator-ibm-java-spring/pull/17 which does the same for the Spring generator.