### PR TITLE
feat: Add support for specifying what Liberty version to use.

### DIFF
--- a/generator-liberty/generators/app/index.js
+++ b/generator-liberty/generators/app/index.js
@@ -16,6 +16,7 @@
 
 'use strict';
 
+const constant = require('../../lib/constant')
 const Generator = require('yeoman-generator');
 const extend = require('extend');
 const Defaults = require('../../lib/defaults');
@@ -30,7 +31,7 @@ module.exports = class extends Generator {
     super(args, opts);
     //create command line options that will be passed by YaaS
     defaults.setOptions(this);
-    extend(this, opts.context);   //inject the objects and functions directly into 'this' to make things easy
+    extend(this, opts.context); //inject the objects and functions directly into 'this' to make things easy
     this.logger.writeToLog(`${logId}:constructor - context`, opts.context);
     this.patterns.push('picnmix');
     this.conf.addMissing(opts, defaults);
@@ -39,9 +40,7 @@ module.exports = class extends Generator {
     this.logger.writeToLog(`${logId}:constructor -  conf (final)`, this.conf);
   }
 
-  initializing() {
-  }
-
+  initializing() {}
 
   prompting() {
     //this generator does not prompt, questions can be set in the prompts directory for testing purposes
@@ -49,11 +48,11 @@ module.exports = class extends Generator {
 
   configuring() {
     this.configure(this);
-    if(this.conf.technologies.includes('swagger')) {
+    if (this.conf.technologies.includes('swagger')) {
       this.conf.enableApiDiscovery = true;
     }
     this.openApiDir = [];
-    if(this.conf.bluemix && this.conf.bluemix.openApiServers && this.conf.bluemix.backendPlatform == 'JAVA' ) {
+    if (this.conf.bluemix && this.conf.bluemix.openApiServers && this.conf.bluemix.backendPlatform == 'JAVA') {
       this.conf.enableApiDiscovery = true;
       return OpenApi.generate(this.conf.bluemix.openApiServers)
         .then(dir => {
@@ -63,19 +62,23 @@ module.exports = class extends Generator {
   }
 
   writing() {
-    if(this.conf.buildType == 'maven') {
+    if (this.conf.buildType == 'maven') {
       this.conf.bxBuildCmd = '`mvn install -Pbluemix -Dcf.org=[your email address] -Dcf.username=[your username] -Dcf.password=[your password]`';
     }
-    if(this.conf.buildType == 'gradle') {
+    if (this.conf.buildType == 'gradle') {
       this.conf.bxBuildCmd = '`gradle build cfPush -PcfOrg=[your email address] -PcfUsername=[your username] -PcfPassword=[your password]`';
     }
-    if(this.openApiDir.length > 0) {
+    if (this.conf.libertyVersion === undefined) {
+      this.conf.libertyVersion = constant.libertyVersion
+    } else if (this.conf.libertyVersion === 'beta') {
+      this.conf.libertyBeta = true
+      this.conf.libertyVersion = constant.libertyBetaVersion
+    }
+    if (this.openApiDir.length > 0) {
       OpenApi.writeFiles(this.openApiDir, this);
     }
-    return this.defaultWriter(this);   //use the default writer supplied by the context.
+    return this.defaultWriter(this); //use the default writer supplied by the context.
   }
 
-  end() {
-  }
-
+  end() {}
 };

--- a/generator-liberty/generators/app/templates/build/build.gradle
+++ b/generator-liberty/generators/app/templates/build/build.gradle
@@ -58,9 +58,9 @@ dependencies {
         {{/each}}
     } {{/if}}
     {{/each}}
-    {{#unless libertybeta}}
-    libertyRuntime ('com.ibm.websphere.appserver.runtime:wlp-webProfile7:17.0.0.4')
-    {{/unless}}
+    {{^libertyBeta}}
+    libertyRuntime ('com.ibm.websphere.appserver.runtime:wlp-webProfile7:{{libertyVersion}}')
+    {{/libertyBeta}}
 }
 
 test {
@@ -88,11 +88,11 @@ task printMessageAboutRunningServer {
 }
 
 liberty {
-    {{#libertybeta}}
+    {{#libertyBeta}}
     install {
-        version = "2018.+"
+        version = "{{libertyVersion}}"
     }
-    {{/libertybeta}}
+    {{/libertyBeta}}
     server{
         apps = [war]
         configFile = file("src/main/liberty/config/server.xml")

--- a/generator-liberty/generators/app/templates/build/pom.xml
+++ b/generator-liberty/generators/app/templates/build/pom.xml
@@ -149,7 +149,7 @@
                     {{#libertyBeta}}
                     <install>
                         <type>webProfile7</type>
-                        <version>2018.+</version>
+                        <version>{{libertyVersion}}</version>
                     </install>
                     {{else}}
                     <assemblyArtifact>

--- a/generator-liberty/generators/app/templates/build/pom.xml
+++ b/generator-liberty/generators/app/templates/build/pom.xml
@@ -146,7 +146,7 @@
                 <groupId>net.wasdev.wlp.maven.plugins</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
                 <configuration>
-                    {{#libertybeta}}
+                    {{#libertyBeta}}
                     <install>
                         <type>webProfile7</type>
                         <version>2018.+</version>
@@ -155,10 +155,10 @@
                     <assemblyArtifact>
                         <groupId>com.ibm.websphere.appserver.runtime</groupId>
                         <artifactId>wlp-webProfile7</artifactId>
-                        <version>17.0.0.4</version>
+                        <version>{{libertyVersion}}</version>
                         <type>zip</type>
                     </assemblyArtifact>
-                    {{/libertybeta}}
+                    {{/libertyBeta}}
                     <configFile>${basedir}/src/main/liberty/config/server.xml</configFile>
                     <serverEnv>${basedir}/src/main/liberty/config/server.env</serverEnv>
                     <jvmOptionsFile>${basedir}/src/main/liberty/config/jvm.options</jvmOptionsFile>

--- a/generator-liberty/generators/prompts/liberty.js
+++ b/generator-liberty/generators/prompts/liberty.js
@@ -104,10 +104,10 @@ Extension.prototype.getQuestions = function () {
     default: false
   }, {
     when: this.show.bind(this),
-    type: 'confirm',
-    name: 'libertybeta',
-    message: 'Install latest beta version of Liberty?',
-    default: (answers) => {return answers.libertybeta}
+    type: 'input',
+    name: 'libertyVersion',
+    message: 'Specify version of Liberty--\'beta\' or a specific GA version.',
+    default: '17.0.0.4'
   }, {
     when: this.show.bind(this),
     type: 'confirm',

--- a/generator-liberty/generators/prompts/liberty.js
+++ b/generator-liberty/generators/prompts/liberty.js
@@ -18,9 +18,11 @@
 
 'use strict'
 
+const defaults = require('../../lib/constant.js')
+
 const PROMPT_ID = 'prompt:liberty'
 
-function Extension (config) {
+function Extension(config) {
   this.id = PROMPT_ID
   this.config = config
   this.context = undefined
@@ -83,13 +85,33 @@ Extension.prototype.getQuestions = function () {
     type: 'input',
     name: 'artifactId',
     message: 'Enter an artifact id for your project',
-    default: (answers) => {return answers.appName}
+    default: (answers) => {
+      return answers.appName
+    }
   }, {
     when: this.show.bind(this),
     type: 'checkbox',
     name: 'technologies',
     message: 'Select the technologies for your project.',
-    choices: [{name: 'rest'}, {name: 'microprofile'}, {name: 'persistence'}, {name: 'websocket'}, {name: 'web'}, {name: 'watsonsdk'}, {name: 'swagger'}, {name: 'springbootweb'}, {name: 'msbuilder'}],
+    choices: [{
+      name: 'rest'
+    }, {
+      name: 'microprofile'
+    }, {
+      name: 'persistence'
+    }, {
+      name: 'websocket'
+    }, {
+      name: 'web'
+    }, {
+      name: 'watsonsdk'
+    }, {
+      name: 'swagger'
+    }, {
+      name: 'springbootweb'
+    }, {
+      name: 'msbuilder'
+    }],
     validate: function (answer) {
       if (answer.length < 1) {
         return 'You must choose at least one technology.'
@@ -107,13 +129,15 @@ Extension.prototype.getQuestions = function () {
     type: 'input',
     name: 'libertyVersion',
     message: 'Specify version of Liberty--\'beta\' or a specific GA version.',
-    default: '17.0.0.4'
+    default: constant.libertyVersion
   }, {
     when: this.show.bind(this),
     type: 'confirm',
     name: 'javametrics',
     message: 'Enable java metrics for your project',
-    default: (answers) => {return answers.javametrics}
+    default: (answers) => {
+      return answers.javametrics
+    }
   }]
 }
 

--- a/generator-liberty/generators/prompts/liberty.js
+++ b/generator-liberty/generators/prompts/liberty.js
@@ -18,7 +18,7 @@
 
 'use strict'
 
-const defaults = require('../../lib/constant.js')
+const constant = require('../../lib/constant.js')
 
 const PROMPT_ID = 'prompt:liberty'
 

--- a/generator-liberty/lib/assert.liberty.js
+++ b/generator-liberty/lib/assert.liberty.js
@@ -79,7 +79,9 @@ function AssertLiberty() {
   this.assertVersion = function (buildType, libertyVersion) {
     describe('contains Liberty version ' + libertyVersion, function () {
       const check = getBuildCheck(true, buildType);
-      if (libertyVersion === constant.libertyBetaVersion) {
+      if (libertyVersion === undefined) {
+        assertLibertyGA(check, buildType, constant.libertyVersion)
+      } else if (libertyVersion === constant.libertyBetaVersion) {
         if (buildType === 'gradle') {
           check.content('version = "' + constant.libertyBetaVersion + '"');
         }
@@ -90,19 +92,23 @@ function AssertLiberty() {
           check.content(betaRegex);
         }
       } else {
-        if (buildType === 'gradle') {
-          check.content('wlp-webProfile7:' + libertyVersion);
-        }
-        if (buildType === 'maven') {
-          const groupId = 'com\\.ibm\\.websphere\\.appserver\\.runtime';
-          const artifactId = 'wlp-webProfile7';
-          const version = libertyVersion.replace(/\./g, '\\.');
-          const content = '<assemblyArtifact>\\s*<groupId>' + groupId + '</groupId>\\s*<artifactId>' + artifactId + '</artifactId>\\s*<version>' + version + '</version>\\s*<type>zip</type>\\s*</assemblyArtifact>';
-          const regex = new RegExp(content);
-          check.content(regex);
-        }
+        assertLibertyGA(check, buildType, libertyVersion)
       }
     });
+  }
+
+  const assertLibertyGA = function (check, buildType, libertyVersion) {
+    if (buildType === 'gradle') {
+      check.content('wlp-webProfile7:' + libertyVersion);
+    }
+    if (buildType === 'maven') {
+      const groupId = 'com\\.ibm\\.websphere\\.appserver\\.runtime';
+      const artifactId = 'wlp-webProfile7';
+      const version = libertyVersion.replace(/\./g, '\\.');
+      const content = '<assemblyArtifact>\\s*<groupId>' + groupId + '</groupId>\\s*<artifactId>' + artifactId + '</artifactId>\\s*<version>' + version + '</version>\\s*<type>zip</type>\\s*</assemblyArtifact>';
+      const regex = new RegExp(content);
+      check.content(regex);
+    }
   }
 
   this.assertNotLoose = function (buildType) {

--- a/generator-liberty/lib/assert.liberty.js
+++ b/generator-liberty/lib/assert.liberty.js
@@ -20,34 +20,34 @@
 'use strict';
 
 const assert = require('yeoman-assert');
+const constant = require('./constant.js')
 const SERVER_XML = 'src/main/liberty/config/server.xml';
 const SERVER_ENV = 'src/main/liberty/config/server.env';
 const README_MD = 'README.md';
 const JVM_OPTIONS = 'src/main/liberty/config/jvm.options';
 const IBM_WEB_EXT = 'src/main/webapp/WEB-INF/ibm-web-ext.xml';
 const JVM_OPTIONS_JAVAAGENT = '-javaagent:resources/javametrics-agent.jar';
-const LIBERTY_BETA_VERSION = '2018.+';   //current Liberty beta version to check for
 const tests = require('ibm-java-codegen-common');
 
 //handy function for checking both existence and non-existence
 function getCheck(exists) {
   return {
-    file : exists ? assert.file : assert.noFile,
-    desc : exists ? 'should create ' : 'should not create ',
-    content : exists ? assert.fileContent : assert.noFileContent
+    file: exists ? assert.file : assert.noFile,
+    desc: exists ? 'should create ' : 'should not create ',
+    content: exists ? assert.fileContent : assert.noFileContent
   }
 }
 
 function getBuildCheck(exists, buildType) {
   return {
-    content : exists ? tests.test(buildType).assertContent : tests.test(buildType).assertNoContent
+    content: exists ? tests.test(buildType).assertContent : tests.test(buildType).assertNoContent
   }
 }
 
 function AssertLiberty() {
-  this.assertAllFiles = function(exists) {
+  this.assertAllFiles = function (exists) {
     const check = getCheck(exists);
-    it(check.desc + 'server.xml, server.env, jvm.options and ibm-web-ext.xml', function() {
+    it(check.desc + 'server.xml, server.env, jvm.options and ibm-web-ext.xml', function () {
       check.file(SERVER_XML);
       check.file(SERVER_ENV);
       check.file(IBM_WEB_EXT);
@@ -56,11 +56,11 @@ function AssertLiberty() {
 
   }
 
-  this.assertJavaMetrics = function(exists, buildType) {
+  this.assertJavaMetrics = function (exists, buildType) {
     const check = getCheck(exists);
     const self = this;
-    describe(check.desc + 'javametrics code, dependencies or features', function() {
-      it(check.desc + 'jvm.options with ' + JVM_OPTIONS_JAVAAGENT, function() {
+    describe(check.desc + 'javametrics code, dependencies or features', function () {
+      it(check.desc + 'jvm.options with ' + JVM_OPTIONS_JAVAAGENT, function () {
         check.content(JVM_OPTIONS, JVM_OPTIONS_JAVAAGENT);
       });
 
@@ -76,24 +76,24 @@ function AssertLiberty() {
     });
   }
 
-  this.assertVersion = function(buildType, libertyVersion) {
-    describe('contains Liberty version ' + libertyVersion, function() {
+  this.assertVersion = function (buildType, libertyVersion) {
+    describe('contains Liberty version ' + libertyVersion, function () {
       const check = getBuildCheck(true, buildType);
-      if(libertyVersion === 'beta') {
-        if(buildType === 'gradle') {
-          check.content('version = "' + LIBERTY_BETA_VERSION + '"');
+      if (libertyVersion === constant.libertyBetaVersion) {
+        if (buildType === 'gradle') {
+          check.content('version = "' + constant.libertyBetaVersion + '"');
         }
-        if(buildType === 'maven') {
-          const betaVersion = LIBERTY_BETA_VERSION.replace(/\./g, '\\.').replace(/\+/g, '\\+');
+        if (buildType === 'maven') {
+          const betaVersion = constant.libertyBetaVersion.replace(/\./g, '\\.').replace(/\+/g, '\\+');
           const betaContent = '<install>\\s*<type>webProfile7</type>\\s*<version>' + betaVersion + '</version>\\s*</install>';
           const betaRegex = new RegExp(betaContent);
           check.content(betaRegex);
         }
       } else {
-        if(buildType === 'gradle') {
+        if (buildType === 'gradle') {
           check.content('wlp-webProfile7:' + libertyVersion);
         }
-        if(buildType === 'maven') {
+        if (buildType === 'maven') {
           const groupId = 'com\\.ibm\\.websphere\\.appserver\\.runtime';
           const artifactId = 'wlp-webProfile7';
           const version = libertyVersion.replace(/\./g, '\\.');
@@ -105,82 +105,82 @@ function AssertLiberty() {
     });
   }
 
-  this.assertNotLoose = function(buildType) {
-    if(buildType === 'maven') {
+  this.assertNotLoose = function (buildType) {
+    if (buildType === 'maven') {
       const check = getBuildCheck(true, buildType);
       check.content(new RegExp('<looseApplication>false</looseApplication>'));
     }
   }
 
-  this.assertArtifactID = function(buildType, id) {
+  this.assertArtifactID = function (buildType, id) {
     const check = getBuildCheck(true, buildType);
-    if(buildType === 'gradle') {
-      it('settings.gradle contains root project setting of ' + id, function() {
+    if (buildType === 'gradle') {
+      it('settings.gradle contains root project setting of ' + id, function () {
         assert.fileContent('settings.gradle', 'rootProject.name = \'' + id + '\'');
       });
     }
-    if(buildType === 'maven') {
+    if (buildType === 'maven') {
       check.content('<artifactId>' + id + '</artifactId>');
     }
   }
 
-  this.assertProperties = function(buildType) {
+  this.assertProperties = function (buildType) {
     const check = tests.test(buildType).assertProperty;
     check('testServerHttpPort', '9080');
     check('testServerHttpsPort', '9443');
-    if(buildType === 'gradle') {
+    if (buildType === 'gradle') {
       check('serverDirectory', '"${buildDir}/wlp/usr/servers/defaultServer"');
       check('warContext', '"${appName}"');
       check('packageFile', '"${project.buildDir}/${rootProject.name}-${version}.zip"');
       check('packagingType', "'usr'");
     }
-    if(buildType === 'maven') {
+    if (buildType === 'maven') {
       check('warContext', '${app.name}');
       check('package.file', '${project.build.directory}/${project.artifactId}-${project.version}.zip');
       check('packaging.type', 'usr');
     }
   }
 
-  this.assertJNDI = function(exists, name, value) {
+  this.assertJNDI = function (exists, name, value) {
     const check = getCheck(exists);
-    it(check.desc + 'a server.xml JDNI entry for ' + name + " = " + value, function() {
+    it(check.desc + 'a server.xml JDNI entry for ' + name + " = " + value, function () {
       check.content(SERVER_XML, '<jndiEntry jndiName="' + name + '" value="' + value + '"/>');
     });
   }
 
-  this.assertEnv = function(exists, name, value) {
+  this.assertEnv = function (exists, name, value) {
     const check = getCheck(exists);
-    it(check.desc + 'a server.env entry for ' + name + " = " + value, function() {
+    it(check.desc + 'a server.env entry for ' + name + " = " + value, function () {
       check.content(SERVER_ENV, name + '="' + value + '"');
     });
   }
 
-  this.assertContextRoot = function(name) {
-    it('contains a ibm-web-ext.xml context root for ' + name, function() {
+  this.assertContextRoot = function (name) {
+    it('contains a ibm-web-ext.xml context root for ' + name, function () {
       assert.fileContent(IBM_WEB_EXT, '<context-root uri="/' + name + '"/>');
     });
   }
 
-  this.assertFeature = function(exists, name) {
+  this.assertFeature = function (exists, name) {
     const check = getCheck(exists);
-    it(SERVER_XML + ' ' + check.desc + 'a feature for ' + name, function() {
+    it(SERVER_XML + ' ' + check.desc + 'a feature for ' + name, function () {
       check.content(SERVER_XML, "<feature>" + name + "</feature>");
     });
   }
 
-  this.assertConfig = function(exists, name) {
+  this.assertConfig = function (exists, name) {
     const check = getCheck(exists);
-    it(SERVER_XML + ' ' + check.desc + 'a tag for ' + name, function() {
+    it(SERVER_XML + ' ' + check.desc + 'a tag for ' + name, function () {
       //look for the closing tag as that will not contain optional attiributes
       check.content(SERVER_XML, "</" + name + ">");
     });
   }
 
-  this.assertPlatforms = function(platforms, buildType, appName) {
-    describe('checks build steps for deploying to IBM Cloud', function() {
+  this.assertPlatforms = function (platforms, buildType, appName) {
+    describe('checks build steps for deploying to IBM Cloud', function () {
       const buildCheck = getBuildCheck(platforms.includes('bluemix'), buildType);
       const check = getCheck(platforms.includes('bluemix'));
-      if(buildType === 'gradle') {
+      if (buildType === 'gradle') {
         buildCheck.content("classpath 'org.cloudfoundry:cf-gradle-plugin:1.1.2'");
         buildCheck.content("cfContext = 'mybluemix.net'");
         buildCheck.content("apply plugin: 'cloudfoundry'");
@@ -189,22 +189,22 @@ function AssertLiberty() {
         buildCheck.content('def checkPropertySet(propertyName)');
         buildCheck.content('cloudfoundry {');
         buildCheck.content("cfPush.dependsOn 'printBluemixProperties'");
-        it(check.desc + 'README with gradle deployment instructions', function() {
+        it(check.desc + 'README with gradle deployment instructions', function () {
           check.content(README_MD, 'gradle build cfPush -PcfOrg=[your email address] -PcfUsername=[your username] -PcfPassword=[your password]');
         });
       }
-      if(buildType === 'maven') {
+      if (buildType === 'maven') {
         const profileContent = '<profile>\\s*<id>bluemix</id>';
         const profileRegex = new RegExp(profileContent);
         buildCheck.content(profileRegex);
         const propertyContent = '<cf.context>mybluemix.net</cf.context>';
         const propertyRegex = new RegExp(propertyContent);
         buildCheck.content(propertyRegex);
-        it(check.desc + 'README with maven deployment instructions', function() {
+        it(check.desc + 'README with maven deployment instructions', function () {
           check.content(README_MD, 'mvn install -Pbluemix -Dcf.org=[your email address] -Dcf.username=[your username] -Dcf.password=[your password]');
         });
       }
-      it(check.desc + 'README deployment instructions', function() {
+      it(check.desc + 'README deployment instructions', function () {
         check.content(README_MD, '**Create Toolchain** button');
         check.content(README_MD, 'contains IBM Cloud specific files');
         check.content(README_MD, 'To deploy the application to IBM Cloud:');

--- a/generator-liberty/lib/assert.liberty.js
+++ b/generator-liberty/lib/assert.liberty.js
@@ -26,7 +26,6 @@ const README_MD = 'README.md';
 const JVM_OPTIONS = 'src/main/liberty/config/jvm.options';
 const IBM_WEB_EXT = 'src/main/webapp/WEB-INF/ibm-web-ext.xml';
 const JVM_OPTIONS_JAVAAGENT = '-javaagent:resources/javametrics-agent.jar';
-const LIBERTY_VERSION = '17.0.0.4';   //current Liberty version to check for
 const LIBERTY_BETA_VERSION = '2018.+';   //current Liberty beta version to check for
 const tests = require('ibm-java-codegen-common');
 
@@ -77,10 +76,10 @@ function AssertLiberty() {
     });
   }
 
-  this.assertVersion = function(buildType, libertybeta) {
-    describe('contains Liberty version ' + LIBERTY_VERSION, function() {
+  this.assertVersion = function(buildType, libertyVersion) {
+    describe('contains Liberty version ' + libertyVersion, function() {
       const check = getBuildCheck(true, buildType);
-      if(libertybeta) {
+      if(libertyVersion === 'beta') {
         if(buildType === 'gradle') {
           check.content('version = "' + LIBERTY_BETA_VERSION + '"');
         }
@@ -92,12 +91,12 @@ function AssertLiberty() {
         }
       } else {
         if(buildType === 'gradle') {
-          check.content('wlp-webProfile7:' + LIBERTY_VERSION);
+          check.content('wlp-webProfile7:' + libertyVersion);
         }
         if(buildType === 'maven') {
           const groupId = 'com\\.ibm\\.websphere\\.appserver\\.runtime';
           const artifactId = 'wlp-webProfile7';
-          const version = LIBERTY_VERSION.replace(/\./g, '\\.');
+          const version = libertyVersion.replace(/\./g, '\\.');
           const content = '<assemblyArtifact>\\s*<groupId>' + groupId + '</groupId>\\s*<artifactId>' + artifactId + '</artifactId>\\s*<version>' + version + '</version>\\s*<type>zip</type>\\s*</assemblyArtifact>';
           const regex = new RegExp(content);
           check.content(regex);

--- a/generator-liberty/lib/constant.js
+++ b/generator-liberty/lib/constant.js
@@ -17,6 +17,6 @@
 'use strict'
 
 module.exports = exports = {
-    libertyVersion: '17.0.0.4',
-    libertyBetaVersion: '2018.+'
+  libertyVersion: '17.0.0.4',
+  libertyBetaVersion: '2018.+'
 }

--- a/generator-liberty/lib/constant.js
+++ b/generator-liberty/lib/constant.js
@@ -14,24 +14,9 @@
  * limitations under the License.
  */
 
-//module for storing default configuration values
+'use strict'
 
-'use strict';
-
-const defaultModule = require('ibm-java-codegen-common').defaults;
-
-const DEFAULTS = {
-  technologies: {
-    desc: 'Technologies to configure when using the prompt:liberty promptType',
-    type: (value) => {
-      return Array.isArray(value) ? value : value.split(",");
-    },
-    default: ['rest']
-  }
-};
-
-module.exports = class extends defaultModule {
-  constructor() {
-    super(DEFAULTS);
-  }
+module.exports = exports = {
+    libertyVersion: '17.0.0.4',
+    libertyBetaVersion: '2018.+'
 }

--- a/generator-liberty/lib/defaults.js
+++ b/generator-liberty/lib/defaults.js
@@ -18,6 +18,7 @@
 
 'use strict';
 
+const constant = require('../lib/constant')
 const defaultModule = require('ibm-java-codegen-common').defaults;
 
 const DEFAULTS = {
@@ -27,6 +28,11 @@ const DEFAULTS = {
       return Array.isArray(value) ? value : value.split(",");
     },
     default: ['rest']
+  },
+  libertyVersion: {
+    desc: 'Version of Liberty to use',
+    type: String,
+    default: constant.libertyVersion
   }
 };
 

--- a/generator-liberty/lib/defaults.js
+++ b/generator-liberty/lib/defaults.js
@@ -21,8 +21,7 @@
 const defaultModule = require('ibm-java-codegen-common').defaults;
 
 const DEFAULTS = {
-  technologies : {desc : 'Technologies to configure when using the prompt:liberty promptType', type : (value)=>{return Array.isArray(value) ? value : value.split(",");}, default : ['rest']},
-  libertybeta : {desc : 'Enable latest beta version of Liberty', type : String, default : undefined}
+  technologies : {desc : 'Technologies to configure when using the prompt:liberty promptType', type : (value)=>{return Array.isArray(value) ? value : value.split(",");}, default : ['rest']}
 };
 
 module.exports = class extends defaultModule {

--- a/generator-liberty/test/integration/generator.liberty.test.js
+++ b/generator-liberty/test/integration/generator.liberty.test.js
@@ -18,6 +18,7 @@
  * Tests the Liberty aspects generator
  */
 'use strict'
+const constant = require('../../lib/constant')
 const path = require('path')
 const helpers = require('yeoman-test')
 const AssertLiberty = require('../../lib/assert.liberty')
@@ -47,9 +48,9 @@ class Options extends AssertLiberty {
     }
     if (libertyVersion === 'beta') {
       this.conf.libertyBeta = true
-    }
-    if (libertyVersion === undefined) {
-      this.conf.libertyVersion = '17.0.0.4'
+      this.conf.libertyVersion = constant.libertyBetaVersion
+    } else if (libertyVersion === undefined) {
+      this.conf.libertyVersion = constant.libertyVersion
     } else {
       this.conf.libertyVersion = libertyVersion
     }

--- a/generator-liberty/test/integration/generator.liberty.test.js
+++ b/generator-liberty/test/integration/generator.liberty.test.js
@@ -29,8 +29,7 @@ const VERSION = '1.0.0'
 const APPNAME = 'testApp'
 
 class Options extends AssertLiberty {
-
-  constructor (buildType, createType, platforms, jndiEntries, envEntries, frameworkDependencies, javametrics, libertybeta) {
+  constructor(buildType, createType, platforms, jndiEntries, envEntries, frameworkDependencies, javametrics, libertyVersion) {
     super()
     this.conf = {
       buildType: buildType,
@@ -44,8 +43,15 @@ class Options extends AssertLiberty {
       appName: APPNAME,
       groupId: GROUPID,
       artifactId: ARTIFACTID,
-      version: VERSION,
-      libertybeta: libertybeta
+      version: VERSION
+    }
+    if (libertyVersion === 'beta') {
+      this.conf.libertyBeta = true
+    }
+    if (libertyVersion === undefined) {
+      this.conf.libertyVersion = '17.0.0.4'
+    } else {
+      this.conf.libertyVersion = libertyVersion
     }
     const ctx = new common.context('test', this.conf)
     this.options = {
@@ -57,59 +63,68 @@ class Options extends AssertLiberty {
         .toPromise()
     }
   }
-
 }
 
-const buildTypes = ['gradle', 'maven']
-const platforms = [[], ['bluemix']]
-const jndiEntries = [{name: 'jndiName', value: 'jndiValue'}]
-const envEntries = [{name: 'envName', value: 'envValue'}]
-const frameworkDependencies = [{'feature': 'testfeature'}]
+// const buildTypes = ['gradle', 'maven']
+const buildTypes = ['maven']
+// const platforms = [[], ['bluemix']]
+const platforms = [
+  []
+]
+const jndiEntries = [{
+  name: 'jndiName',
+  value: 'jndiValue'
+}]
+const envEntries = [{
+  name: 'envName',
+  value: 'envValue'
+}]
+const frameworkDependencies = [{
+  'feature': 'testfeature'
+}]
 
 describe('java liberty generator : Liberty server integration test', function () {
-
   buildTypes.forEach(buildType => {
     platforms.forEach(platformArray => {
       describe('Generates server configuration (no technologies) ' + buildType + ' with platforms ' + platformArray, function () {
-        const options = new Options(buildType, 'picnmix', platformArray, jndiEntries, envEntries, frameworkDependencies, false, false)
+        const options = new Options(buildType, 'picnmix', platformArray, jndiEntries, envEntries, frameworkDependencies, false)
         before(options.before.bind(options))
-        options.assertAllFiles(true)
-        options.assertJavaMetrics(false, buildType)
-        options.assertContextRoot(APPNAME)
-        options.assertVersion(buildType, false)
-        options.assertProperties(buildType)
-        options.assertPlatforms(platformArray, buildType, APPNAME)
-        options.assertNotLoose(buildType)
-        jndiEntries.forEach(entry => {
-          options.assertJNDI(true, entry.name, entry.value)
-        })
-        envEntries.forEach(entry => {
-          options.assertEnv(true, entry.name, entry.value)
-        })
-        frameworkDependencies.forEach(entry => {
-          options.assertFeature(true, entry.feature)
-        })
+        // options.assertAllFiles(true)
+        // options.assertJavaMetrics(false, buildType)
+        // options.assertContextRoot(APPNAME)
+        options.assertVersion(buildType, options.conf.libertyVersion)
+        // options.assertProperties(buildType)
+        // options.assertPlatforms(platformArray, buildType, APPNAME)
+        // options.assertNotLoose(buildType)
+        // jndiEntries.forEach(entry => {
+        //   options.assertJNDI(true, entry.name, entry.value)
+        // })
+        // envEntries.forEach(entry => {
+        //   options.assertEnv(true, entry.name, entry.value)
+        // })
+        // frameworkDependencies.forEach(entry => {
+        //   options.assertFeature(true, entry.feature)
+        // })
       })
     })
 
-    describe('Check artifact id for ' + buildType, function () {
-      const options = new Options(buildType, 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, false, false)
-      before(options.before.bind(options))
-      options.assertArtifactID(buildType, options.conf.artifactId)
-    })
+    // describe('Check artifact id for ' + buildType, function () {
+    //   const options = new Options(buildType, 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, false, false)
+    //   before(options.before.bind(options))
+    //   options.assertArtifactID(buildType, options.conf.artifactId)
+    // })
 
-    describe('Generates correct build config when libertybeta is set to true', function () {
-      const options = new Options(buildType, 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, false, true)
+    describe('Generates correct build config when libertyVersion is set to beta', function () {
+      const options = new Options(buildType, 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, false, 'beta')
       before(options.before.bind(options))
-      options.assertVersion(buildType, true)
+      options.assertVersion(buildType, options.conf.libertyVersion)
     })
   })
-
 })
 
-describe('Generates server configuration (no technologies) maven with deploy type with java metrics', function () {
-  const options = new Options('maven', 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, true, false)
-  before(options.before.bind(options))
-  options.assertAllFiles(true)
-  options.assertJavaMetrics(true, 'maven')
-})
+// describe('Generates server configuration (no technologies) maven with deploy type with java metrics', function () {
+//   const options = new Options('maven', 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, true, false)
+//   before(options.before.bind(options))
+//   options.assertAllFiles(true)
+//   options.assertJavaMetrics(true, 'maven')
+// })

--- a/generator-liberty/test/integration/generator.liberty.test.js
+++ b/generator-liberty/test/integration/generator.liberty.test.js
@@ -17,7 +17,9 @@
 /**
  * Tests the Liberty aspects generator
  */
+
 'use strict'
+
 const constant = require('../../lib/constant')
 const path = require('path')
 const helpers = require('yeoman-test')
@@ -66,11 +68,10 @@ class Options extends AssertLiberty {
   }
 }
 
-// const buildTypes = ['gradle', 'maven']
-const buildTypes = ['maven']
-// const platforms = [[], ['bluemix']]
+const buildTypes = ['gradle', 'maven']
 const platforms = [
-  []
+  [],
+  ['bluemix']
 ]
 const jndiEntries = [{
   name: 'jndiName',
@@ -90,30 +91,30 @@ describe('java liberty generator : Liberty server integration test', function ()
       describe('Generates server configuration (no technologies) ' + buildType + ' with platforms ' + platformArray, function () {
         const options = new Options(buildType, 'picnmix', platformArray, jndiEntries, envEntries, frameworkDependencies, false)
         before(options.before.bind(options))
-        // options.assertAllFiles(true)
-        // options.assertJavaMetrics(false, buildType)
-        // options.assertContextRoot(APPNAME)
+        options.assertAllFiles(true)
+        options.assertJavaMetrics(false, buildType)
+        options.assertContextRoot(APPNAME)
         options.assertVersion(buildType, options.conf.libertyVersion)
-        // options.assertProperties(buildType)
-        // options.assertPlatforms(platformArray, buildType, APPNAME)
-        // options.assertNotLoose(buildType)
-        // jndiEntries.forEach(entry => {
-        //   options.assertJNDI(true, entry.name, entry.value)
-        // })
-        // envEntries.forEach(entry => {
-        //   options.assertEnv(true, entry.name, entry.value)
-        // })
-        // frameworkDependencies.forEach(entry => {
-        //   options.assertFeature(true, entry.feature)
-        // })
+        options.assertProperties(buildType)
+        options.assertPlatforms(platformArray, buildType, APPNAME)
+        options.assertNotLoose(buildType)
+        jndiEntries.forEach(entry => {
+          options.assertJNDI(true, entry.name, entry.value)
+        })
+        envEntries.forEach(entry => {
+          options.assertEnv(true, entry.name, entry.value)
+        })
+        frameworkDependencies.forEach(entry => {
+          options.assertFeature(true, entry.feature)
+        })
       })
     })
 
-    // describe('Check artifact id for ' + buildType, function () {
-    //   const options = new Options(buildType, 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, false, false)
-    //   before(options.before.bind(options))
-    //   options.assertArtifactID(buildType, options.conf.artifactId)
-    // })
+    describe('Check artifact id for ' + buildType, function () {
+      const options = new Options(buildType, 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, false)
+      before(options.before.bind(options))
+      options.assertArtifactID(buildType, options.conf.artifactId)
+    })
 
     describe('Generates correct build config when libertyVersion is set to beta', function () {
       const options = new Options(buildType, 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, false, 'beta')
@@ -123,9 +124,9 @@ describe('java liberty generator : Liberty server integration test', function ()
   })
 })
 
-// describe('Generates server configuration (no technologies) maven with deploy type with java metrics', function () {
-//   const options = new Options('maven', 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, true, false)
-//   before(options.before.bind(options))
-//   options.assertAllFiles(true)
-//   options.assertJavaMetrics(true, 'maven')
-// })
+describe('Generates server configuration (no technologies) maven with deploy type with java metrics', function () {
+  const options = new Options('maven', 'picnmix', [], jndiEntries, envEntries, frameworkDependencies, true)
+  before(options.before.bind(options))
+  options.assertAllFiles(true)
+  options.assertJavaMetrics(true, 'maven')
+})


### PR DESCRIPTION
- `libertybeta` renamed to `libertyVersion`
- if `beta` is entered, Liberty beta is used
- if a version number is entered, the GA at that version is used
- if undefined, GA `17.0.0.4` is used
- created `lib/constant.js` which holds `libertyVersion` and `libertyBetaVersion`, so when version numbers change, the generator only needs to be updated in one place 