### PR TITLE
fix: Updated so that npm test can use multi mocha reporters

### DIFF
--- a/generator-liberty/config.json
+++ b/generator-liberty/config.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled":"list, xunit-file",
+  "xunitReporterOptions":{
+    "output":"xunit.xml"
+  }
+}

--- a/generator-liberty/package-lock.json
+++ b/generator-liberty/package-lock.json
@@ -2758,6 +2758,27 @@
         }
       }
     },
+    "mocha-multi-reporters": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.1.7.tgz",
+      "integrity": "sha1-zH8/TTL0eFIJQdhSq7ZNmYhYfYI=",
+      "dev": true,
+      "requires": {
+        "debug": "3.1.0",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "modify-values": {
       "version": "1.0.0",
       "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/bmd-npm-virtual/modify-values/-/modify-values-1.0.0.tgz",

--- a/generator-liberty/package.json
+++ b/generator-liberty/package.json
@@ -23,20 +23,21 @@
     "coveralls": "^2.13.3",
     "eslint": "^4.13.1",
     "mocha": "^3.2.0",
+    "mocha-multi-reporters": "^1.1.7",
     "nyc": "^11.3.0",
     "standard-version": "^4.2.0",
     "xunit-file": "^1.0.0",
     "yeoman-test": "^1.6.0"
   },
   "scripts": {
-    "test": "nyc mocha test/unit/*",
+    "test": "nyc --reporter=lcov mocha test/unit/* --reporter mocha-multi-reporters --reporter-options configFile=config.json",
     "testint": "nyc mocha test/integration/*",
     "testdefaults": "nyc mocha test/integration/generator.defaults.test.js",
     "testliberty": "nyc mocha test/integration/generator.liberty.*",
     "testtech": "nyc mocha test/integration/generator.technologies.*",
     "testopenapi": "nyc mocha test/integration/generator.openapi.test.js",
     "lint": "eslint .",
-    "mocha": "nyc --reporter=lcov mocha --recursive -R xunit-file",
+    "mocha": "nyc --reporter=lcov mocha test/unit/* --reporter mocha-multi-reporters --reporter-options configFile=config.json",
     "coveralls": "nyc report --reporter=text-lcov | coveralls",
     "prerelease": "npm test && npm run testint",
     "release": "standard-version"


### PR DESCRIPTION
Now we can use the standard "list" mocha reporter along with the "xunit-file" mocha reporter. This allows us to see the errors on standard out and adds the output to the xunit file that is used for the devops insights dashboard.