### PR TITLE
fix: arf/planning-languages repo issue# 424: Increase polling rate

### DIFF
--- a/generator-liberty/generators/app/templates/liberty/src/main/liberty/config/server.xml
+++ b/generator-liberty/generators/app/templates/liberty/src/main/liberty/config/server.xml
@@ -30,6 +30,7 @@
 
   <!-- Automatically expand WAR files and EAR files -->
   <applicationManager autoExpand="true"/>
+  <applicationMonitor pollingRate="1000ms"/>
 
   <webApplication name="{{artifactId}}" location="${app.location}"/>
 

--- a/generator-liberty/generators/app/templates/liberty/src/main/liberty/config/server.xml
+++ b/generator-liberty/generators/app/templates/liberty/src/main/liberty/config/server.xml
@@ -30,6 +30,7 @@
 
   <!-- Automatically expand WAR files and EAR files -->
   <applicationManager autoExpand="true"/>
+
   <applicationMonitor pollingRate="1000ms"/>
 
   <webApplication name="{{artifactId}}" location="${app.location}"/>


### PR DESCRIPTION
The default pollingRate for liberty server is 500ms, which is too quick and resulting in double updates on microclimate. Need the generator to increase the pollingRate in server.xml to be 1s.



Details: https://github.ibm.com/arf/planning-languages/issues/424
https://github.com/OpenLiberty/open-liberty/issues/4548